### PR TITLE
Add spacehey icon

### DIFF
--- a/profiles/icons.md
+++ b/profiles/icons.md
@@ -65,6 +65,7 @@ Want to add an icon? Update this page with a pull request.
 | Rep.ly                     | fa-solid fa-message-dots              | rep.ly                                                |
 | Snapchat                   | fa-brands fa-snapchat                 | snapchat.com                                          |
 | SoundCloud                 | fa-brands fa-soundcloud               | soundcloud.com                                        |
+| SpaceHey                   | omg-icon spacehey                     | spacehey.com, blog.spacehey.com                       |
 | Spotify                    | fa-brands fa-spotify                  | spotify.com, open.spotify.com                         |
 | Stack Overflow             | fa-brands fa-stack-overflow           | stackoverflow.com                                     |
 | Steam Community            | fa-brands fa-steam                    | steamcommunity.com                                    |


### PR DESCRIPTION
Hi there!
I'm building [SpaceHey](https://spacehey.com), a retro social network! I'd love to have an icon for SpaceHey on omg.lol profiles!
![screenshot](https://user-images.githubusercontent.com/18481195/132204429-d937a255-94e3-4c4e-846f-7f73a9c64241.png)

I added an entry for spacehey in the Markdown file, but couldn't find a way to actually add the icon file (svg?) to the repo as `omg-icon spacehey` - how does this work?

Thank you!

Edit: The SpaceHey Icon (in PNG or SVG) format can be downloaded here: https://spacehey.com/brand