### PR TITLE
feat: Add monokai theme

### DIFF
--- a/profiles/themes/monokai.css
+++ b/profiles/themes/monokai.css
@@ -4,7 +4,7 @@ Theme: Monokai
 Author: Dakota Chambers (@dcchambers)
 License: MIT
 Version: 1.0
-Description: Monokai - your code editor's favorite color palette. Adapted from the Monokai color scheme by Wimer Hazenberg (@monokai).
+Description: Your text editor's favorite color palette. Adapted from the Monokai color scheme by Wimer Hazenberg (@monokai).
 
 */
 

--- a/profiles/themes/monokai.css
+++ b/profiles/themes/monokai.css
@@ -1,0 +1,84 @@
+/*
+
+Theme: Monokai
+Author: Dakota Chambers (@dcchambers)
+License: MIT
+Version: 1.0
+Description: Monokai - your code editor's favorite color palette. Adapted from the Monokai color scheme by Wimer Hazenberg (@monokai).
+
+*/
+
+body {
+    background: #363537;
+    color: #F7F1FF;
+}
+
+main {
+    background: unset;
+}
+
+a:link,
+a:visited {
+    color: #F7F1FF;
+    text-decoration-color: #F7F1FF;
+    text-decoration: none;
+    border-bottom: 1px dotted #F7F1FF;
+}
+
+a:hover,
+a:active {
+    color: #A5A5A5;
+    text-decoration-color: #A5A5A5;
+    text-decoration: none;
+    border-bottom: 2px solid #A5A5A5;
+}
+
+#profile-picture {
+    border-radius: 100%;
+}
+
+#pronouns {
+    color: #A5A5A5;
+}
+
+#footer a:link, #footer a:visited, #footer a:hover, #footer a:active {
+    color: #A5A5A5;
+}
+
+/* Color for profile items list */
+.fa-li, .fas, .omg-icon {
+    color: #FA638D;
+    fill: #FA638D;
+    stroke: #FA638D;
+}
+
+/* Specific colors for individual icons */
+.fa-plug {
+    color: #FBE46E;
+}
+
+.fa-badge-check {
+    color: #60D4E4 !important; /* important is needed to override inline style*/
+}
+
+.fa-briefcase {
+    color: #FB935A;
+}
+
+.fa-map-marker-alt {
+    color: #948CDF;
+}
+
+/* Additional theming for OMGEX (https://github.com/litdevs/omgex) */
+
+.fa-clock {
+    color: #7DD792;
+}
+
+.fa-smile-plus {
+    color: #60D4E4;
+}
+
+.fa-birthday-cake {
+    color: #FA638D;
+}

--- a/profiles/themes/themes.json
+++ b/profiles/themes/themes.json
@@ -76,6 +76,17 @@
 			"description": "No style at all, for those who want to do their own thing!",
 			"url": "https://meta.omg.lol/meta/profiles/themes/naked.css",
 			"repo": "https://github.com/neatnik/omg.lol/tree/main/profiles/themes"
+		},
+		"monokai": {
+			"name": "Monokai",
+			"author": "Dakota Chambers",
+			"author_url": "https://dakota.omg.lol",
+			"version": "1.0",
+			"license": "MIT",
+			"license_url": "https://opensource.org/licenses/MIT",
+			"description": "Your text editor's favorite color palette. Adapted from the Monokai color scheme by Wimer Hazenberg (@monokai).",
+			"url": "https://meta.omg.lol/meta/profiles/themes/monokai.css",
+			"repo": "https://github.com/dcchambers/omg.lol/tree/main/profiles/themes"
 		}
 	}
 }


### PR DESCRIPTION
Adds a theme based on the monokai color scheme by Wimer Hazenberg.
- Includes some additional color theming for anyone using [OMGEX](https://github.com/litdevs/omgex)
- Live example: [dakota.omg.lol](https://dakota.omg.lol)

![image](https://user-images.githubusercontent.com/3454131/142915707-84fb867e-f666-4e3a-ad85-1effb9164bb5.png)
