### PR TITLE
Automate labelling of PRs and add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugs.yml
+++ b/.github/ISSUE_TEMPLATE/bugs.yml
@@ -1,0 +1,15 @@
+name: Minor Bug Report
+description: Report non-critical/minor bugs
+title: "[Bug]: "
+labels: [bug]
+body:
+- type: textarea
+  attributes:
+    label: Describe the Bug
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Reproduction Steps (Optional)
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Major Bug Report
+    url: mailto:bugs@omg.lol
+    about: Report critical/major bugs and vulns to the mailbox

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Major Bug Report
-    url: mailto:bugs@omg.lol
+    url: https://mailxto.com/29nbr4g0a1
     about: Report critical/major bugs and vulns to the mailbox

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+documentation:
+  - any: ['info/**/*.md', '!info/README.md']
+profile:
+  - any: ['profiles/themes/*.css']

--- a/.github/workflows/label_pr.yml
+++ b/.github/workflows/label_pr.yml
@@ -1,0 +1,16 @@
+name: Label PRs
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
In case you want to add more labels to the config the documentation for labeler can be found here: https://github.com/actions/labeler#usage