### PR TITLE
Add GitHub "Sponsor" button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://omg.lol/sign-up


### PR DESCRIPTION
_edit: thank you all for your insightful comments_

This PR adds the required file for the GitHub sponsor button, which shows people where they can sponsor the repository. In this case, that's the OMG.LOL sign up link! :^)

The button looks like this:
![sponsor](https://user-images.githubusercontent.com/46850780/195435139-005f6c4f-9b5e-4498-a392-b7f51e3b9fb5.png)
![sponsorpanel](https://user-images.githubusercontent.com/46850780/195435143-1d393f1a-b150-4282-890b-7e30a2c6c748.png)

Make sure that you have "Sponsorships" enabled in the settings of this repository. This allows the button to be displayed, and should not be confused with GitHub Sponsors, which allows you to donate money to organizations or users. Confusing!

**When you have merged the PR**, [go here](https://github.com/neatnik/omg.lol/settings) and enable the "Sponsorships" setting. The button should then appear! Fun.
![image](https://user-images.githubusercontent.com/46850780/195435337-7af3d9fe-63e6-495f-a655-cb64ab611d69.png)
