### PR TITLE
Add bilibili icon

### DIFF
--- a/profiles/icons/domains.json
+++ b/profiles/icons/domains.json
@@ -7,6 +7,7 @@
     "backloggery.com": "backloggery",
     "bandcamp.com": "bandcamp",
     "behance.net": "behance",
+    "bilibili.*": "bilibili",
     "blogger.com": "blogger",
     "bookshop.org": "bookshop",
     "buymeacoffee.com": "buymeacoffee",


### PR DESCRIPTION
stupid questions ahead
---
I used a wildcard because the [global](https://bilibili.tv) and [chinese](https://bilibili.com) sites are under different subdomains.
Should I just use two entries for this instead?

I am assuming icons apply to the subdomains as well. If not... can a wildcard be used? `*.bilibili.*`?