### PR TITLE
Change ebay to be a partial domain

### DIFF
--- a/profiles/icons/defined_domains.txt
+++ b/profiles/icons/defined_domains.txt
@@ -50,8 +50,7 @@ deviantart.com deviantart
 discord. discord
 discourse.org discourse
 dribbble.com dribbble
-ebay.com ebay
-ebay.de ebay
+ebay. ebay
 etsy.com etsy
 example.com example
 eyeem.com eyeem

--- a/profiles/icons/defined_domains.txt
+++ b/profiles/icons/defined_domains.txt
@@ -51,6 +51,7 @@ discord. discord
 discourse.org discourse
 dribbble.com dribbble
 ebay.com ebay
+ebay.de ebay
 etsy.com etsy
 example.com example
 eyeem.com eyeem


### PR DESCRIPTION
Ebay.com was supported but if i were to link to the german ebay (ebay.de) it wouldn't show the icon