### PR TITLE
Don't run icon sync on forks

### DIFF
--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   deploy:
-    if: github.repository == 'neatnik/omg.lol'
+    if: github.repository_owner == 'neatnik'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   deploy:
+    if: github.repository == 'neatnik/omg.lol'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
When I've been adding new icons to my fork, I've been getting emails about the workflow failing.
Fair enough - I haven't set up the credentials for the DigitalOcean space, because I don't have them, and I shouldn't have them either.

That being said, it's pretty annoying!
This change will have the workflow check if it's being run in the `neatnik` organization. If it is, then it will execute as normal, but if it isn't, it's a fork and [will be skipped automatically](https://github.com/Vukkyy/omg.lol/actions/runs/3331898447/jobs/5512169098).

(If the organization is ever renamed from `neatnik`, this will need to be changed!)