### PR TITLE
Add lazer.ppy.sh

### DIFF
--- a/profiles/icons/defined_domains.txt
+++ b/profiles/icons/defined_domains.txt
@@ -28,6 +28,7 @@ ruby.social mastodon
 dice.camp mastodon
 
 // Other
+lazer.ppy.sh osu
 nicovideo.jp niconico
 .onion tor
 fandom.com fandom


### PR DESCRIPTION
Scores set on osu!lazer are on a separate site from the main osu.ppy.sh at this time.