### PR TITLE
Added default image width, markdown images from pics were not styled at all

### DIFF
--- a/profiles/themes/neobrutalism.css
+++ b/profiles/themes/neobrutalism.css
@@ -23,6 +23,10 @@
 	color: var(--white);
 }
 
+img {
+	width: 100%;
+}
+
 body {
 	background: var(--yellow);
 	color: var(--black);


### PR DESCRIPTION
Markdown images from pics were overflowing

`![](https://cdn.some.pics/codeaviary/66f0eec610315.png)`